### PR TITLE
Ignore bitstream junk from aja helo

### DIFF
--- a/src/nal/sps.rs
+++ b/src/nal/sps.rs
@@ -914,7 +914,10 @@ impl SeqParameterSet {
             frame_cropping: FrameCropping::read(&mut r)?,
             vui_parameters: VuiParameters::read(&mut r)?,
         };
-        r.finish_rbsp()?;
+        // AJA Helo plus sends invalid bytes after the SPS
+        // and our current use case never passes something that needs to be full read (such as a cursor),
+        // so we just ignore the rest of the data.
+        // r.finish_rbsp()?;
         Ok(sps)
     }
 

--- a/src/rbsp.rs
+++ b/src/rbsp.rs
@@ -68,7 +68,9 @@ impl<R: BufRead> ByteReader<R> {
             inner,
             state: ParseState::HeaderByte,
             i: 0,
-            max_fill: 128,
+            // Can't look ahead more then 1 bytes, since
+            // some encoders pass junk data after the SPS NAL.
+            max_fill: 1,
         }
     }
 


### PR DESCRIPTION
Just ignore trailing bits after we have correctly read an SPS.
And set all reader to just look 1 byte ahead, so that we dont look on the junk that AJA Helo submits.

```
 // --- sps nalu
// sps nalu header (0b0010_0111 & 0b0001_1111 = 7 = SPS)
0x27, 
// sps data
0x4d, 0x40 ,0x28, 0x8b, 0x95, 0x80, 0xf0, 0x04, 0x4f, 0xcb, 
0xff, 0x80, 0x00, 0x80, 0x00, 0x88, 0x00, 0x00, 0x1f, 0x48, 
0x00, 0x07, 0x53, 0x07, 0x00, 0x00, 0x03, 0x00, 
0x98, 0x96, 0x80, 
0x00, 0x13, 0x12, 0xd1, 0x7b, 0xdd, 0x61, 
0x00, 0x00, 0x00, 0x04,  // This is invalid in a NALU bitstream.
// sps done
```