### PR TITLE
Slice length

### DIFF
--- a/src/nal/slice/mod.rs
+++ b/src/nal/slice/mod.rs
@@ -434,6 +434,7 @@ pub struct SliceHeader {
     pub sp_for_switch_flag: Option<bool>,
     pub slice_qs: Option<u32>,
     pub disable_deblocking_filter_idc: u8,
+    pub length: u32,
 }
 impl SliceHeader {
     pub fn from_bits<'a, R: BitRead>(
@@ -658,6 +659,7 @@ impl SliceHeader {
             sp_for_switch_flag,
             slice_qs,
             disable_deblocking_filter_idc,
+            length: r.length(),
         };
         Ok((header, sps, pps))
     }

--- a/src/rbsp.rs
+++ b/src/rbsp.rs
@@ -355,7 +355,6 @@ impl<R: std::io::BufRead + Clone> BitRead for BitReader<R> {
             return Err(BitReaderError::ExpGolombTooLarge(name));
         } else if count > 0 {
             let val: u32 = self.read(count, name)?;
-
             Ok((1 << count) - 1 + val)
         } else {
             Ok(0)

--- a/src/rbsp.rs
+++ b/src/rbsp.rs
@@ -308,6 +308,7 @@ pub trait BitRead {
     /// already byte-aligned.
     fn finish_sei_payload(self) -> Result<(), BitReaderError>;
 
+    /// Returns the number of bits read so far.
     fn length(&self) -> u32;
 }
 


### PR DESCRIPTION
Add support for calculating slice length.

I'm not sure this is exactly correct, as the interface of the underlying BitReader makes it a bit hard to get the number of bytes read for some methods. It's mostly correct for `SliceHeader::from_bits` at least, as we working DRM when skipping these bits (aligned to nearest byte).

Needed to support DRM CBCS pattern encryption